### PR TITLE
Remove AdSense components and meta injection from UI

### DIFF
--- a/src/components/EnhancedLandingPage.jsx
+++ b/src/components/EnhancedLandingPage.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import BeforeAfterSlider from './BeforeAfterSlider';
 import Button from '../components/ui/Button.jsx';
-import AdSenseBox from './AdSenseBox.jsx';
 import '../styles/EnhancedLandingPage.css';
 import '../styles/tokens.css';
 
@@ -39,16 +38,6 @@ const EnhancedLandingPage = () => {
       img.src = src;
     });
 
-    // Inject required AdSense meta tag into head (page-scoped)
-    const META_NAME = 'google-adsense-account';
-    const META_CONTENT = 'ca-pub-3347414112529675';
-    const existing = document.head.querySelector(`meta[name="${META_NAME}"]`);
-    if (!existing) {
-      const meta = document.createElement('meta');
-      meta.setAttribute('name', META_NAME);
-      meta.setAttribute('content', META_CONTENT);
-      document.head.appendChild(meta);
-    }
   }, []);
 
   const handleOpenDemo = () => {
@@ -69,11 +58,7 @@ const EnhancedLandingPage = () => {
   return (
     <div className="enhanced-landing">
       <div className="landing-hero">
-        <div className="hero-content" style={{ display: 'grid', gridTemplateColumns: 'minmax(220px, 280px) 1fr', gap: 16 }}>
-          {/* Left free space panel: non-distracting ad */}
-          <div className="hero-left-rail" aria-hidden="false">
-            <AdSenseBox layout="landing" />
-          </div>
+        <div className="hero-content">
           <div className="hero-headline">
             <h1 className="hero-title">
               Pro‑grade RAW Editor

--- a/src/pages/EditorPage.jsx
+++ b/src/pages/EditorPage.jsx
@@ -22,7 +22,6 @@ import LocalAdjustmentsPanel from '../components/LocalAdjustmentsPanel';
 import GradientMaskOverlay from '../components/GradientMaskOverlay';
 import { buildLUTsFromCurves } from '../utils/curveUtils';
 import FileUploader from '../components/FileUploader';
-import AdSenseBox from '../components/AdSenseBox.jsx';
 import EditorUploadPlaceholder from '../components/EditorUploadPlaceholder';
 import EnhancedImageCanvas from '../components/EnhancedImageCanvas';
 import ExportDialog from '../components/ExportDialog';
@@ -544,12 +543,8 @@ const EditorPage = () => {
         <div className="editor-main">
           <div className="canvas-container" style={{ minHeight: 320 }}>
             {!uploadedImage ? (
-              <div className="upload-placeholder" style={{ display: 'grid', gap: 12 }}>
+              <div className="upload-placeholder">
                 <FileUploader onFileUpload={handleFileUpload} />
-                {/* Non-distracting ad below upload button */}
-                <div aria-hidden="false" style={{ justifySelf: 'start' }}>
-                  <AdSenseBox layout="editor" />
-                </div>
               </div>
             ) : (
               <>


### PR DESCRIPTION
- Remove AdSenseBox usage from EnhancedLandingPage and EditorPage
- Drop page-scoped AdSense meta tag injection on landing
- Simplify hero and upload placeholder layouts Reason: declutter UI and eliminate ad dependencies/components