### PR TITLE
Configure asset caching and rewrites in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,43 @@
 {
+  "headers": [
+    {
+      "source": "/assets/(.*)\\.js",
+      "headers": [
+        { "key": "Content-Type", "value": "application/javascript; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/assets/(.*)\\.css",
+      "headers": [
+        { "key": "Content-Type", "value": "text/css; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/(index|vendor|utils|.*)-.*\\.js",
+      "headers": [
+        { "key": "Content-Type", "value": "application/javascript; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/(index|vendor|utils|.*)-.*\\.css",
+      "headers": [
+        { "key": "Content-Type", "value": "text/css; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ],
   "rewrites": [
+    {
+      "source": "/assets/(.*)",
+      "destination": "/assets/$1"
+    },
+    {
+      "source": "/(index|vendor|utils|.*)-.*\\.(js|css|map)",
+      "destination": "/$1.$2"
+    },
     {
       "source": "/(.*)",
       "destination": "/"


### PR DESCRIPTION
- Add headers for JS/CSS to set correct Content-Type and long-term immutable caching
- Add rewrites to serve versioned (hashed) assets and maps from unversioned files
- Improve cacheability and correct MIME types for static assets