### PR TITLE
build: Use relative base path in Vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   // Deploy at root for Vercel
-  const base = '/'
+  const base = './'
 
   return {
     plugins: [react()],


### PR DESCRIPTION
Change the `base` option from `'/'` to `'./'` to switch from absolute to relative asset paths.

This allows the built application to be deployed to a subdirectory or opened directly from the filesystem, ensuring that assets like CSS and JavaScript are loaded correctly.